### PR TITLE
remove function related to padding

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,7 +30,6 @@
 - [Signing Orders](helper-libraries/signing-orders.md)
 - [Hashing Orders](helper-libraries/hashing-orders.md)
 - [Testing Token Balances](helper-libraries/testing-token-balances.md)
-- [Padding Locators](helper-libraries/padding-locators.md)
 - [Testing with Time Travel](helper-libraries/testing-time-travel.md)
 
 ## Instant (Legacy)

--- a/helper-libraries/padding-locators.md
+++ b/helper-libraries/padding-locators.md
@@ -1,15 +1,3 @@
 When Ethereum addresses are used as the locator for an entry on the Indexer, the locator must be stored as a bytes32 not an address to be consistent with the other types of locators. `padding.js` provides a function to pad addresses into a bytes32 format.
 
 You can find the `padding.js` library on NPM within [@airswap/test-utils](https://www.npmjs.com/package/@airswap/test-utils) or on the [AirSwap GitHub](https://github.com/airswap/airswap-protocols/blob/master/utils/test-utils/src/padding.js)
-
-# Functions
-
-## `padAddressToLocator`
-
-Pads a given Ethereum address into a bytes32 to be used as a locator on the Indexer. Ethereum addresses are 190 bits and a bytes32 is 256 bits.
-
-| Param      | Type       | Description                                 |
-| :--------- | :--------- | :------------------------------------------ |
-| `address`  | `address`  | The address to be padded to a bytes32.      | 
-
-**Returns** the address right padded with 66 0s.

--- a/helper-libraries/padding-locators.md
+++ b/helper-libraries/padding-locators.md
@@ -1,3 +1,0 @@
-When Ethereum addresses are used as the locator for an entry on the Indexer, the locator must be stored as a bytes32 not an address to be consistent with the other types of locators. `padding.js` provides a function to pad addresses into a bytes32 format.
-
-You can find the `padding.js` library on NPM within [@airswap/test-utils](https://www.npmjs.com/package/@airswap/test-utils) or on the [AirSwap GitHub](https://github.com/airswap/airswap-protocols/blob/master/utils/test-utils/src/padding.js)


### PR DESCRIPTION
Remove function related to padAddressToLocator

Next steps will be to reword the documentation to indicate that the locator field is of length bytes 32
Inputs to the locator field are constrained to that length but may include addresses, URLs, or any comms protocol identifier.